### PR TITLE
Fix pointer arithmetic

### DIFF
--- a/md4.c
+++ b/md4.c
@@ -82,16 +82,17 @@ void md4_init(struct md4_ctx *ctx) {
  */
 void md4_update(struct md4_ctx *ctx, const void *data, unsigned long len) {
     unsigned char * byte_data = (unsigned char *)data;
+    unsigned char * byte_block = (unsigned char *)ctx->block;
     // block中空余的字节数
     const u32 avail = sizeof(ctx->block) - (ctx->byte_count & 0x3f);
     ctx->byte_count += len;
     // data不足以装满一个block则存入后直接返回
     if (avail > len) {
-        memcpy(ctx->block + (sizeof(ctx->block) - avail), byte_data, len);
+        memcpy(byte_block + (sizeof(ctx->block) - avail), byte_data, len);
         return;
     }
     // 装满一个block后更新状态寄存器
-    memcpy(ctx->block + (sizeof(ctx->block) - avail), byte_data, avail);
+    memcpy(byte_block + (sizeof(ctx->block) - avail), byte_data, avail);
     // TODO
     md4_transform(ctx->hash, ctx->block);
     byte_data += avail;


### PR DESCRIPTION
In `md4_init` `ctx->block` is used as a char pointer, but it's type is a 4 byte integer pointer. This causes the memcpy to overwrite additional bytes, such as the `byte_count` variable, causing bad hashes, or even crashes.

This code illustrates the bug: https://gist.github.com/moex3/3da7b8624addec6fe992c788e610d023

This PR fixes this.